### PR TITLE
[TIG-115] Adding default_auto_field to the app

### DIFF
--- a/apps.py
+++ b/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class RestHooksAppConfig(AppConfig):
+	name = 'rest_hooks'
+	default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Adding default_auto_field set to the current id type in order to avoid a migration if this conflicts with settings.DEFAULT_AUTO_FIELD.

Now that `settings.DEFAULT_AUTO_FIELD` is set to `'django.db.models.BigAutoField'`, we need this app to have as its default auto field the current type (`AutoField`) otherwise it'll need a migration that we don't want.